### PR TITLE
Enable poll locator for CT

### DIFF
--- a/data/states.json
+++ b/data/states.json
@@ -91,7 +91,8 @@
       "phone": "(860) 509-6100"
     },
     "regLink": "https://voterregistration.ct.gov/OLVR/welcome.do",
-    "chkLink": "https://voterregistration.ct.gov/OLVR/welcome.do"
+    "chkLink": "https://voterregistration.ct.gov/OLVR/welcome.do",
+    "pollWgt": true
   },
   "DC": {
     "name": "D.C.",


### PR DESCRIPTION
Based on a sample address lookup, it looks like CT polling locations have been loaded into the API.

cc @schneidmaster 
